### PR TITLE
DEPLOYMENT: npm run build fails with error TS2345

### DIFF
--- a/packages/shared/src/markdown/render.ts
+++ b/packages/shared/src/markdown/render.ts
@@ -3,7 +3,7 @@ import remarkParse from 'remark-parse';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkRehype from 'remark-rehype';
 import rehypeStringify from 'rehype-stringify';
-import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import rehypeSanitize, { defaultSchema, type Options as SanitizeSchema } from 'rehype-sanitize';
 import { visit } from 'unist-util-visit';
 import type { Root, Text, Link } from 'mdast';
 import { extractWikilinks, isImageEmbed, type WikilinkToken } from './wikilink.js';
@@ -115,7 +115,7 @@ export async function renderMarkdown(
 
   // Customize sanitization to allow our wikilink classes and transclusion elements
   // rehype-sanitize uses [attrName, ...allowedValues] format for value-restricted attrs
-  const sanitizeSchema = {
+  const sanitizeSchema: SanitizeSchema = {
     ...defaultSchema,
     tagNames: [...(defaultSchema.tagNames ?? []), 'div'],
     attributes: {


### PR DESCRIPTION
DEPLOYMENT failure:
npm run build fails with error TS2345;

The issue is that sanitizeSchema is inferred with a type that doesn't satisfy Schema from rehype-sanitize. TypeScript can't
  reconcile the spread of defaultSchema.attributes with the custom tuple entries. The fix is to import Schema and explicitly type the
   variable.

The fix was:

  1. Import Options (the schema type alias) from rehype-sanitize — this package re-exports hast-util-sanitize's Schema type under the
   name Options.
  2. Explicitly annotate sanitizeSchema with that type so TypeScript can verify it satisfies .use(rehypeSanitize, ...).

Claude Code diagnosed and provided this fix.