### PR TITLE
specify 'main' branch on git repo init; git push defaults to 'main'

### DIFF
--- a/packages/server/src/services/git.ts
+++ b/packages/server/src/services/git.ts
@@ -47,7 +47,8 @@ export class GitService {
 
   /** Initialize a new git repo at the configured directory. */
   async init(): Promise<void> {
-    await exec('git', ['init', this.repoDir]);
+    // Specify 'main' to match push default
+    await exec('git', ['init', '-b', 'main', this.repoDir]);
   }
 
   /** Clone a remote repo into the configured directory. */


### PR DESCRIPTION
I ran into breakdowns when testing DEPLOYMENT:  
- viz., repository init worked, but subsequent push failed because, in some cases, repository initialization created a 'master' branch  
- this update insures that new repos are created with default branch 'main' (this matches what is specified on the push code)  
