### PR TITLE
Missing-page → new-page redirect; smarter cursor focus on new-page form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 node_modules/
 dist/
 data/
+data-repro/
 .env
 env.sh
+*.bak
 *.db
 *.db-journal
 *.db-wal

--- a/packages/web/src/components/Editor.tsx
+++ b/packages/web/src/components/Editor.tsx
@@ -16,12 +16,13 @@ interface EditorProps {
   placeholder?: string;
   pages?: PageInfo[];
   wikiSlug?: string;
+  focusOnMount?: boolean;
   onSave?: () => void;
   onCancel?: () => void;
   onUpload?: (file: File) => Promise<string | null>;
 }
 
-export function Editor({ value, onChange, placeholder, pages, wikiSlug, onSave, onCancel, onUpload }: EditorProps) {
+export function Editor({ value, onChange, placeholder, pages, wikiSlug, focusOnMount, onSave, onCancel, onUpload }: EditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const autocompleteCompartment = useRef(new Compartment());
@@ -88,6 +89,10 @@ export function Editor({ value, onChange, placeholder, pages, wikiSlug, onSave, 
     });
 
     viewRef.current = view;
+
+    if (focusOnMount) {
+      view.focus();
+    }
 
     return () => {
       view.destroy();

--- a/packages/web/src/pages/PageEdit.tsx
+++ b/packages/web/src/pages/PageEdit.tsx
@@ -144,7 +144,7 @@ export function PageEdit() {
           value={newTitle}
           onChange={(e) => setNewTitle(e.target.value)}
           className="w-full px-3 py-2 border rounded-lg mb-4 text-lg"
-          autoFocus
+          autoFocus={!newTitle}
         />
       )}
 
@@ -214,6 +214,7 @@ export function PageEdit() {
             onChange={setContent}
             pages={pageList}
             wikiSlug={wiki}
+            focusOnMount={isNew && !!newTitle}
             onSave={handleSave}
             onCancel={() => {
               const cleanPath = urlPath?.replace(/\/edit$/, '');

--- a/packages/web/src/pages/PageView.tsx
+++ b/packages/web/src/pages/PageView.tsx
@@ -50,13 +50,27 @@ export function PageView() {
     }
 
     Promise.all([
-      pagesApi.get(wikiSlug, urlPath),
+      pagesApi.get(wikiSlug, urlPath).catch(() => null),
       pagesApi.list(wikiSlug),
       wikisApi.get(wikiSlug),
-      pagesApi.backlinks(wikiSlug, urlPath),
+      pagesApi.backlinks(wikiSlug, urlPath).catch(() => ({ backlinks: [] as PageInfo[] })),
       // Fetch sidebar (may not exist — that's fine)
       pagesApi.get(wikiSlug, '_sidebar').catch(() => null),
-    ]).then(async ([{ page: newPage }, { pages: allPages }, { wiki }, { backlinks: bl }, sidebarResult]) => {
+    ]).then(async ([pageResult, { pages: allPages }, { wiki }, { backlinks: bl }, sidebarResult]) => {
+      // Missing page: follow the wiki's incipientLinkStyle setting for authenticated users.
+      // Logged-out readers stay on "Page not found" rather than getting bounced through /login.
+      if (!pageResult) {
+        if ((wiki.incipientLinkStyle ?? 'create') === 'create' && user) {
+          const derivedTitle = urlPath.replace(/_/g, ' ');
+          navigate(`/${wikiSlug}/_new?title=${encodeURIComponent(derivedTitle)}`, { replace: true });
+          return;
+        }
+        setPage(null);
+        setLoading(false);
+        return;
+      }
+
+      const newPage = pageResult.page;
       let rendered = await renderMarkdown(
         newPage.content,
         `/${wikiSlug}`,
@@ -89,7 +103,7 @@ export function PageView() {
       setPage(null);
       setLoading(false);
     });
-  }, [wikiSlug, urlPath]);
+  }, [wikiSlug, urlPath, user, navigate]);
 
   if (loading && !page) return <div className="p-8 text-gray-500">Loading...</div>;
   if (error) return <div className="p-8 text-red-600">{error}</div>;


### PR DESCRIPTION
Two small UX fixes from John Abbe ("Slow") feedback, 2026-05-17.

## Fixes

- Closes #6 — navigating to a non-existent page within a wiki now follows the wiki's `incipientLinkStyle` setting (`create` → redirect to `/_new?title=…`, `highlight` → keep "Page not found"). Generalizes incipient-link behavior from a particular syntactic form (`[[Foo]]`) to "the state of arriving at a missing page." Logged-out readers stay on "Page not found" rather than getting bounced through `/login`.
- Closes #7 — on `/:wiki/_new`, when the title is pre-filled via `?title=` (incipient click, or the new missing-page redirect), focus lands in the content editor instead of the title input. The no-title case (clicking "New Page" from `WikiHome`) keeps focusing the title.

## Mechanics

- `PageView.tsx`: page-get and backlinks calls now `.catch(() => …)` so a 404 doesn't reject the batch; missing-page branch checks `wiki.incipientLinkStyle` and `user`, then `navigate(..., { replace: true })` so the back button still works as expected.
- `PageEdit.tsx`: title input `autoFocus={!newTitle}`; passes `focusOnMount={isNew && !!newTitle}` to `Editor`.
- `Editor.tsx`: adds `focusOnMount?: boolean` prop; calls `view.focus()` after view creation when set.
- `.gitignore`: adds `data-repro/` and `*.bak` to cover local dev state and env-file backups.

## Notes

- `urlPath` → title derivation is just `_ → space`. The full inverse of `scrubPath` would also handle `? # % "`, but those rarely appear in user-typed URLs and the new-page form lets the user fix the title before saving anyway.
- Per-wiki `incipientLinkStyle` default is `create`, so the redirect is on by default. The `highlight` opt-out preserves the "don't auto-offer creation" semantics.

## Test plan

- [ ] As a logged-in user, click an incipient wikilink (`[[Foo]]`) — still goes to `_new?title=Foo`, cursor in content editor.
- [ ] As a logged-in user, click a Markdown link to a non-existent page (`[Foo](/wiki/Foo)`) — now also goes to `_new?title=Foo`, cursor in content editor.
- [ ] As a logged-in user, type a non-existent URL — same redirect.
- [ ] As a logged-out user, visit a non-existent page URL — stays on "Page not found", no login redirect.
- [ ] Wiki set to `highlight` mode, logged-in user visits non-existent page — stays on "Page not found."
- [ ] Click "New Page" from `WikiHome` (no `?title=`) — cursor lands in title input.
- [ ] Edit an existing page (no `?title=`) — pre-existing focus behavior unchanged.

Marked draft pending a manual pass through the test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)