### PR TITLE
Page delete UI: Danger Zone disclosure on the edit page

### DIFF
--- a/packages/web/src/pages/PageEdit.tsx
+++ b/packages/web/src/pages/PageEdit.tsx
@@ -10,11 +10,15 @@ export function PageEdit() {
   const navigate = useNavigate();
   const [content, setContent] = useState('');
   const [pagePath, setPagePath] = useState('');
+  const [pageTitle, setPageTitle] = useState('');
   const [preview, setPreview] = useState('');
   const [showPreview, setShowPreview] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [pageList, setPageList] = useState<PageInfo[]>([]);
+  const [showDangerZone, setShowDangerZone] = useState(false);
+  const [deleteConfirmInput, setDeleteConfirmInput] = useState('');
+  const [deleting, setDeleting] = useState(false);
   const isNew = !urlPath;
 
   // For new pages — pre-fill title from ?title= query param (incipient link click)
@@ -33,6 +37,7 @@ export function PageEdit() {
     pagesApi.get(wiki, cleanPath).then(({ page }) => {
       setContent(page.content);
       setPagePath(page.path);
+      setPageTitle(page.title);
     }).catch((err) => setError(err.message));
   }, [wiki, urlPath, isNew]);
 
@@ -59,6 +64,21 @@ export function PageEdit() {
       navigate(href);
     }
   }, [navigate]);
+
+  async function handleDelete() {
+    if (!wiki || !urlPath) return;
+    setDeleting(true);
+    setError('');
+
+    try {
+      const cleanPath = urlPath.replace(/\/edit$/, '');
+      await pagesApi.delete(wiki, cleanPath);
+      navigate(`/${wiki}`);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Delete failed');
+      setDeleting(false);
+    }
+  }
 
   async function handleSave() {
     if (!wiki) return;
@@ -131,6 +151,59 @@ export function PageEdit() {
       {error && (
         <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-800 text-sm">
           {error}
+        </div>
+      )}
+
+      {!isNew && (
+        <div className="flex justify-end mb-2">
+          <button
+            type="button"
+            onClick={() => {
+              setShowDangerZone(!showDangerZone);
+              setDeleteConfirmInput('');
+            }}
+            className="text-xs text-gray-500 hover:text-red-600"
+          >
+            {showDangerZone ? '× Close delete panel' : 'Delete this page…'}
+          </button>
+        </div>
+      )}
+
+      {!isNew && showDangerZone && (
+        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg space-y-3">
+          <h2 className="text-sm font-semibold text-red-700">Danger Zone</h2>
+          <p className="text-sm text-red-800">
+            This will delete <code className="bg-red-100 px-1 rounded">{pageTitle}</code> and
+            commit the removal to the wiki's git history. The page text remains recoverable from
+            git, but links to this page will break until it's restored or replaced.
+          </p>
+          <p className="text-sm text-red-800 font-medium">
+            Type <code className="bg-red-100 px-1 rounded">{pageTitle}</code> to confirm:
+          </p>
+          <input
+            type="text"
+            value={deleteConfirmInput}
+            onChange={(e) => setDeleteConfirmInput(e.target.value)}
+            className="w-full px-3 py-2 border border-red-300 rounded-lg text-sm"
+            placeholder={pageTitle}
+          />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleteConfirmInput !== pageTitle || deleting}
+              className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 text-sm font-medium"
+            >
+              {deleting ? 'Deleting...' : 'Permanently delete page'}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setShowDangerZone(false); setDeleteConfirmInput(''); }}
+              className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm"
+            >
+              Cancel
+            </button>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
Closes #9.

Adds a way to delete an individual wiki page from the web UI. Reported by Bill Anderson (@band).

## UX

When editing an existing page, a subtle gray text trigger appears below the action bar, right-aligned:

> Delete this page…

Clicking it expands an inline **Danger Zone** panel above the editor, with a red border, a brief description of what the delete does (commits a removal to git; text remains recoverable from history; backlinks will break until restored), and a type-the-title confirmation field. The Permanently-delete button stays disabled until the input exactly matches the page title.

The pattern matches `WikiSettings.tsx`'s wiki-delete Danger Zone, but lives above the editor rather than below because the editor is visually the bottom of the page — a footer-style Danger Zone would be invisible for long pages.

The trigger is hidden on `/_new` (no page to delete yet), and the Cancel button collapses the panel and clears the confirm input. The server-side `DELETE /api/wikis/:wiki/pages/*` route already existed (`routes/pages.ts:200`) and enforces editor-or-higher access; this PR just wires up the affordance.

## Design notes

- Subtle by default: gray text, no border, no destructive coloring on the trigger itself.
- Confirmation friction: typed-title match, not just a "Are you sure?" — same friction model as wiki delete.
- Positioned above the editor so users don't have to scroll past a long edit field to find it.
- Doesn't crowd the Save/Cancel/Preview action bar — its own row, separated by whitespace.

## Test plan

- [ ] Editing an existing page shows the "Delete this page…" trigger.
- [ ] Trigger opens a Danger Zone panel above the editor.
- [ ] Permanently delete button is disabled until the title is typed correctly.
- [ ] On successful delete, user is returned to the wiki home and the page no longer appears in the list.
- [ ] Cancel closes the panel and clears the typed input.
- [ ] On `/:wiki/_new`, the trigger does not appear.
- [ ] A non-editor user (when finer permissions land via #10) shouldn't see this — currently still rendered, but the server-side 403 would surface as an error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)