### PR TITLE
Responsive page headers; prose overflow defensives for narrow viewports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4464,6 +4464,32 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
@@ -4500,6 +4526,107 @@
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0",
         "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4661,6 +4788,127 @@
       "license": "MIT",
       "dependencies": {
         "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -5891,6 +6139,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -5918,6 +6184,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8271,6 +8552,7 @@
         "rehype-sanitize": "^6.0.0",
         "rehype-stringify": "^10.0.1",
         "remark-frontmatter": "^5.0.0",
+        "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.1",
         "unified": "^11.0.5",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -21,20 +21,21 @@
     "test": "vitest"
   },
   "dependencies": {
-    "unified": "^11.0.5",
-    "remark-parse": "^11.0.0",
-    "remark-rehype": "^11.1.1",
-    "remark-frontmatter": "^5.0.0",
-    "rehype-stringify": "^10.0.1",
-    "rehype-sanitize": "^6.0.0",
     "mdast-util-from-markdown": "^2.0.2",
     "mdast-util-to-hast": "^13.2.0",
     "micromark-util-character": "^2.1.1",
+    "rehype-sanitize": "^6.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.1",
+    "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
+    "@types/node": "^22.12.0",
     "typescript": "^5.7.3",
-    "vitest": "^3.0.5",
-    "@types/node": "^22.12.0"
+    "vitest": "^3.0.5"
   }
 }

--- a/packages/shared/src/markdown/render.ts
+++ b/packages/shared/src/markdown/render.ts
@@ -1,5 +1,6 @@
 import { unified } from 'unified';
 import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkRehype from 'remark-rehype';
 import rehypeStringify from 'rehype-stringify';
@@ -129,6 +130,7 @@ export async function renderMarkdown(
 
   const processor = unified()
     .use(remarkParse)
+    .use(remarkGfm)
     .use(remarkFrontmatter, ['yaml'])
     .use(() => (tree: Root) => {
       // Extract frontmatter

--- a/packages/web/src/pages/PageEdit.tsx
+++ b/packages/web/src/pages/PageEdit.tsx
@@ -107,7 +107,7 @@ export function PageEdit() {
 
   return (
     <div className="max-w-5xl mx-auto p-4 sm:p-8">
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+      <div className="flex flex-col min-[440px]:flex-row min-[440px]:items-center min-[440px]:justify-between gap-3 mb-4">
         <Link to={`/${wiki}`} className="text-sm text-gray-500 hover:text-gray-700">
           &larr; Back to wiki
         </Link>

--- a/packages/web/src/pages/PageEdit.tsx
+++ b/packages/web/src/pages/PageEdit.tsx
@@ -106,12 +106,12 @@ export function PageEdit() {
   }
 
   return (
-    <div className="max-w-5xl mx-auto p-8">
-      <div className="flex items-center justify-between mb-4">
+    <div className="max-w-5xl mx-auto p-4 sm:p-8">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
         <Link to={`/${wiki}`} className="text-sm text-gray-500 hover:text-gray-700">
           &larr; Back to wiki
         </Link>
-        <div className="flex gap-2">
+        <div className="flex gap-2 shrink-0 flex-wrap">
           <button
             onClick={() => setShowPreview(!showPreview)}
             className="px-3 py-1.5 border border-gray-300 rounded text-sm hover:bg-gray-50"

--- a/packages/web/src/pages/PageView.tsx
+++ b/packages/web/src/pages/PageView.tsx
@@ -97,7 +97,7 @@ export function PageView() {
 
   const mainContent = (
     <div className={sidebarHtml ? 'flex-1 min-w-0' : 'max-w-3xl mx-auto w-full'}>
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
+      <div className="flex flex-col min-[440px]:flex-row min-[440px]:items-center min-[440px]:justify-between gap-3 mb-6">
         <div className="min-w-0 flex-1">
           <Link to={`/${wikiSlug}`} className="text-sm text-gray-500 hover:text-gray-700">
             &larr; Back to wiki

--- a/packages/web/src/pages/PageView.tsx
+++ b/packages/web/src/pages/PageView.tsx
@@ -97,14 +97,14 @@ export function PageView() {
 
   const mainContent = (
     <div className={sidebarHtml ? 'flex-1 min-w-0' : 'max-w-3xl mx-auto w-full'}>
-      <div className="flex items-center justify-between mb-6">
-        <div>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
+        <div className="min-w-0 flex-1">
           <Link to={`/${wikiSlug}`} className="text-sm text-gray-500 hover:text-gray-700">
             &larr; Back to wiki
           </Link>
-          <h1 className="text-2xl font-bold text-gray-900 mt-1">{page.title}</h1>
+          <h1 className="text-xl sm:text-2xl font-bold text-gray-900 mt-1 break-words">{page.title}</h1>
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-2 shrink-0">
           {user && (
             <Link
               to={`/${wikiSlug}/${urlPath}/edit`}
@@ -152,10 +152,10 @@ export function PageView() {
 
   if (sidebarHtml) {
     return (
-      <div className="max-w-5xl mx-auto p-8 flex gap-8">
+      <div className="max-w-5xl mx-auto p-4 sm:p-8 flex flex-col sm:flex-row gap-4 sm:gap-8">
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
         <aside
-          className="w-56 flex-shrink-0 prose prose-sm prose-blue max-w-none"
+          className="w-full sm:w-56 sm:flex-shrink-0 prose prose-sm prose-blue max-w-none"
           dangerouslySetInnerHTML={{ __html: sidebarHtml }}
           onClick={handleContentClick}
         />
@@ -165,7 +165,7 @@ export function PageView() {
   }
 
   return (
-    <div className="max-w-3xl mx-auto p-8">
+    <div className="max-w-3xl mx-auto p-4 sm:p-8">
       {mainContent}
     </div>
   );

--- a/packages/web/src/pages/WikiHome.tsx
+++ b/packages/web/src/pages/WikiHome.tsx
@@ -68,7 +68,7 @@ export function WikiHome() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 sm:p-8">
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
+      <div className="flex flex-col min-[440px]:flex-row min-[440px]:items-center min-[440px]:justify-between gap-3 mb-6">
         <h1 className="text-xl sm:text-2xl font-bold text-gray-900 min-w-0 break-words">{wiki.title}</h1>
         <div className="flex gap-2 shrink-0">
           {user && (

--- a/packages/web/src/pages/WikiHome.tsx
+++ b/packages/web/src/pages/WikiHome.tsx
@@ -67,10 +67,10 @@ export function WikiHome() {
   const regularPages = pageList.filter((p) => !p.path.startsWith('_') && !p.path.startsWith('.'));
 
   return (
-    <div className="max-w-3xl mx-auto p-8">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">{wiki.title}</h1>
-        <div className="flex gap-2">
+    <div className="max-w-3xl mx-auto p-4 sm:p-8">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
+        <h1 className="text-xl sm:text-2xl font-bold text-gray-900 min-w-0 break-words">{wiki.title}</h1>
+        <div className="flex gap-2 shrink-0">
           {user && (
             <Link
               to={`/${wikiSlug}/_settings`}

--- a/packages/web/src/styles/index.css
+++ b/packages/web/src/styles/index.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Prose overflow defensives — keep narrow viewports from forcing page-level zoom
+   when content contains long URLs, wide code blocks, or wide tables. */
+.prose pre { overflow-x: auto; max-width: 100%; }
+.prose a { overflow-wrap: anywhere; }
+.prose table { display: block; overflow-x: auto; max-width: 100%; }
+
 /* Wikilinks */
 .prose a.wikilink {
   text-decoration-color: currentColor;


### PR DESCRIPTION
Closes #12, #14.

## What

- **Responsive header** in three pages (`PageView`, `PageEdit`, `WikiHome`):
  - Switches from `flex justify-between` to `flex-col min-[440px]:flex-row min-[440px]:items-center min-[440px]:justify-between gap-3`. Stacks vertically only on viewports narrower than 440px; side-by-side everywhere else.
  - Title block gets `min-w-0 flex-1` so it can shrink, and `text-xl sm:text-2xl break-words` so an unbreakable title (like "WelcomeVisitors") can break at any character on mobile.
  - Action buttons get `shrink-0` so they stay together.
  - Outer container padding `p-8` → `p-4 sm:p-8` to give narrow viewports more usable width.
- **Sidebar layout** on `PageView` also stacks on narrow viewports (`flex-col sm:flex-row`, `w-full sm:w-56`) so the 224px aside doesn't squeeze the main content.
- **Global prose defensives** in `index.css`:
  ```css
  .prose pre { overflow-x: auto; max-width: 100%; }
  .prose a { overflow-wrap: anywhere; }
  .prose table { display: block; overflow-x: auto; max-width: 100%; }
  ```
- **`remark-gfm` added to the markdown pipeline.** Two issues testing surfaced:
  - Tables didn't render — `remark-parse` alone doesn't recognize GFM pipe-tables.
  - Bare URLs in paragraphs stayed as plain text, so the `.prose a` wrap rule couldn't reach them.
  Both fixed by enabling GFM. Side effect: strikethrough, task lists, and footnotes are now also available.

## Why

Reported by John Abbe ("Slow") at https://wiki.p5lab.net/jottit/WelcomeVisitors on iPhone — the page rendered too wide and clipped text on the right. Investigation traced it primarily to the **header** in `PageView.tsx`:

- `WelcomeVisitors` at `text-2xl` is ~200px wide and can't break (no spaces).
- `flex justify-between` defaults to `min-width: auto` on its children, so the title and buttons each kept their intrinsic widths.
- `p-8` ate 64px of padding.
- Total minimum: ~437px on a 390px viewport.

Stacking on narrow viewports, allowing the title to break, and letting the buttons travel together is the structural fix. The global prose rules are a separate but related class of safety — long URLs, code blocks, and tables in *any* page would have caused the same kind of overflow. The remark-gfm enable was discovered along the way: the bare-URL case wasn't reachable from the `.prose a` rule until autolinks were on.

## Breakpoint choice

Original draft used Tailwind's `sm:` (640px), which forced stacking far earlier than the layout actually needed. Tightened to `min-[440px]:` after Pete pointed out the layout had plenty of room well below 640px. PageEdit (with 3 buttons + Back-to-wiki) is the tightest of the three at ~350px min; PageView and WikiHome hold side-by-side down to ~210px. 440px is a safe threshold above which nothing crowds.

## Test plan

Mobile / narrow viewport:
- [ ] PageView at 375px (iPhone SE) with `WelcomeVisitors` title — no horizontal overflow, title wraps at character boundaries.
- [ ] Drag-resize through 640 → 440 — layout stays side-by-side until 440px, then snaps to stacked.
- [ ] PageView with `_sidebar.md` — sidebar stacks above content on narrow, side-by-side on desktop.
- [ ] PageEdit at 375px — Back to wiki + Preview/Cancel/Save buttons don't overflow; danger zone trigger and panel still positioned correctly.
- [ ] WikiHome at 375px — wiki title + Settings/New Page buttons don't overflow.

Markdown rendering:
- [ ] GFM table with 6+ columns renders, scrolls horizontally inside its block on narrow viewports.
- [ ] Bare URL in a paragraph becomes a clickable `<a>` and wraps cleanly inside the prose column.
- [ ] Long Markdown-link URL as link text (`[https://very/long/url](https://example.org/x)`) wraps cleanly.
- [ ] Code block with a single long line scrolls horizontally inside the `<pre>` rather than pushing the page wider.
- [ ] Normal short links and wikilinks still look ordinary — no spurious mid-word breaks from `overflow-wrap: anywhere`.

Desktop:
- [ ] All three pages at 1024px+ look identical to pre-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
